### PR TITLE
Fix canvas by upgrading needle

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
   },
   "scripts": {
     "vercel-build": "yum install libuuid-devel libmount-devel && cp /lib64/{libuuid,libmount,libblkid}.so.1 node_modules/canvas/build/Release/"
+  },
+  "resolutions": {
+    "**/needle": "^2.5.2"
   }
 }


### PR DESCRIPTION
`canvas` is broken with newer versions of Node.js, due to a bug in `needle`.

Related issues:

- https://github.com/Automattic/node-canvas/issues/1663#issuecomment-691535641
- https://github.com/Automattic/node-canvas/issues/1650#issuecomment-675834681
- https://github.com/tomas/needle/issues/312

The solution is to force the `needle` dependency to upgrade using [yarn resolutions](https://classic.yarnpkg.com/en/docs/selective-version-resolutions/#toc-how-to-use-it) 🚀 